### PR TITLE
Remove sizes from Javascript and use CSS

### DIFF
--- a/css/README.md
+++ b/css/README.md
@@ -11,6 +11,7 @@ At a bare minimum, add this:
 
 ```
 <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
+<link href="https://jessgusclark.github.io/gadget-material-icons/css/icons.css" rel="stylesheet" />
 ```
 
 ## Customizations

--- a/css/icons.css
+++ b/css/icons.css
@@ -12,8 +12,13 @@
 
 
 /* Edit Mode 
-The background colors behind the placeholder GIF:
+The sizes and background colors behind the placeholder GIF:
 */
+img.material-icons.sm {width:24px; height: 24px;}
+img.material-icons.md {width:50px; height: 50px;}
+img.material-icons.lg {width:100px; height:100px;}
+img.material-icons.xl {width:200px; height:200px;}
+
 img.material-icons.blue {background-color:#013C66}
 img.material-icons.gold {background-color:#F6B000}
 img.material-icons.gray {background-color:#EBEBEB}

--- a/gadget/src/js/html.js
+++ b/gadget/src/js/html.js
@@ -10,28 +10,7 @@ var htmlBuilder = (function(){
 
 		buildTransformation : function(icon, size, color){
 
-			// hard coded needs to be refactored
-			var px;
-
-			switch(size){
-				case 'sm':
-					px = 24;
-				break;
-				case 'md':
-					px = 50;
-				break;
-				case 'lg':
-					px = 100;
-				break;
-				case 'xl':
-					px = 200;
-				break;
-
-				default:
-					px = 24;
-			}
-
-			return '<img src="https://jessgusclark.github.io/gadget-material-icons/gadget/dist/img/placeholder.svg" class="material-icons ' + size + ' ' + color + '" width="' + px +'" height="' + px + '" alt="' + icon + '" />';
+			return '<img src="https://jessgusclark.github.io/gadget-material-icons/gadget/dist/img/placeholder.svg" class="material-icons ' + size + ' ' + color + '" alt="' + icon + '" />';
 
 		}
 

--- a/gadget/test/test-html.js
+++ b/gadget/test/test-html.js
@@ -22,7 +22,7 @@ describe('build html', function() {
 
 	it ('should return image transformation', function(){
 
-		var expected = '<img src="https://jessgusclark.github.io/gadget-material-icons/gadget/dist/img/placeholder.svg" class="material-icons sm black" width="24" height="24" alt="bridge" />';
+		var expected = '<img src="https://jessgusclark.github.io/gadget-material-icons/gadget/dist/img/placeholder.svg" class="material-icons sm black" alt="bridge" />';
 
 		assert.equal(expected,
 						 html.buildTransformation(icon, size, color));


### PR DESCRIPTION
Removes sizes from JavaScript and uses CSS instead. This will allow administrators to use custom sizes in both edit mode and production and able to make one change. Previously, an administrator would have to go into the JavaScript to change the size of the placeholder image. 

If administrators are using the CND from github, they will need to add the following code to their CSS or the placeholder images' size may be 100%:

```
img.material-icons.sm {width:24px; height: 24px;}
img.material-icons.md {width:50px; height: 50px;}
img.material-icons.lg {width:100px; height:100px;}
img.material-icons.xl {width:200px; height:200px;}
```

This code was added to [icons.css](https://github.com/jessgusclark/gadget-material-icons/blob/master/css/icons.css), line 17-22.

This resolves issue #3 .
